### PR TITLE
Misc. enhancements, fixes, and cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 
 [[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +250,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spin_sleep",
+ "uuid",
  "zmq",
 ]
 
@@ -330,6 +342,12 @@ name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-error"
@@ -441,6 +459,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -568,10 +616,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ee9362deb4a96cef4d437d1ad49cffc9b9e92d202b6995674e928ce684f112"
 
 [[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+dependencies = [
+ "getrandom",
+ "rand",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ pyo3-log = "0.6.0"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
 spin_sleep = "1.1.1"
+uuid = { version = "1.1.2", features = ["v4", "fast-rng"] }
 zmq = { version = "0.9.2", features = ["vendored"] }
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ec.setDetectorConfig('ntrigger', nimages)
 result = ec.sendDetectorCommand('arm')
 sequence_id = result['sequence id'] 
 
-frames = libertem_dectris.FrameChunkedIterator()
+frames = libertem_dectris.FrameChunkedIterator(uri="tcp://localhost:9999")
 # start to receive data for the given series
 # (can be called multiple times on the same `FrameChunkedIterator` instance)
 frames.start(series=sequence_id)
@@ -48,3 +48,38 @@ try:
 finally:
     frames.close()  # clean up background thread etc.
 ```
+
+## Changelog
+
+### v0.2.0 (unreleased)
+
+- Added `libertem_dectris.headers` submodule that exports header classes
+- Added ways to create `libertem_dectris.Frame` and `libertem_dectris.FrameStack`
+  objects from Python, mostly useful for testing
+- Added binding to random port for the simulator
+- Properly parametrize with zmq endpoint URI
+- Fix many clippy complaints
+
+### v0.1.0
+
+Initial release!
+
+## Development
+
+This package is using [pyo3](https://pyo3.rs/) with
+[maturin](https://maturin.rs/) to create the Python bindings.  First, make sure
+`maturin` is installed in your Python environment:
+
+```bash
+(venv) $ pip install maturin
+```
+
+Then, after each change to the rust code, run `maturin develop -r` to build and
+install a new version of the wheel.
+
+## Release
+
+- update changelog above
+- bump version in Cargo.toml if not already bumped, and push
+- create a release from the GitHub UI, creating a new tag vX.Y.Z
+- done!

--- a/examples/testchunked.py
+++ b/examples/testchunked.py
@@ -7,7 +7,7 @@ from libertem_live.detectors.dectris.DEigerClient import DEigerClient
 @click.command()
 @click.argument('nimages', type=int)
 def main(nimages: int):
-    frames = libertem_dectris.FrameChunkedIterator()
+    frames = libertem_dectris.FrameChunkedIterator(uri="tcp://127.0.0.1:9999")
 
     ec = DEigerClient('localhost', 8910)
 

--- a/examples/testflame.py
+++ b/examples/testflame.py
@@ -5,7 +5,7 @@ from libertem_live.detectors.dectris.DEigerClient import DEigerClient
 
 if __name__ == "__main__":
     ec = DEigerClient("localhost", 8910)
-    frames = libertem_dectris.FrameChunkedIterator()
+    frames = libertem_dectris.FrameChunkedIterator(uri="tcp://127.0.0.1:9999")
 
     frames.start()
 

--- a/examples/testserialize.py
+++ b/examples/testserialize.py
@@ -1,7 +1,7 @@
 import libertem_dectris
 
 if __name__ == "__main__":
-    frames = libertem_dectris.FrameChunkedIterator()
+    frames = libertem_dectris.FrameChunkedIterator(uri="tcp://127.0.0.1:9999")
     frames.start()
 
     frame_stack = frames.get_next_stack(max_size=32)

--- a/examples/testtooslow.py
+++ b/examples/testtooslow.py
@@ -2,7 +2,7 @@ import time
 import libertem_dectris
 
 if __name__ == "__main__":
-    frames = libertem_dectris.FrameIterator()
+    frames = libertem_dectris.FrameIterator(uri="tcp://127.0.0.1:9999")
 
     frames.start(series=14)
 

--- a/examples/testuser.py
+++ b/examples/testuser.py
@@ -6,7 +6,7 @@ from libertem_live.detectors.dectris.DEigerClient import DEigerClient
 @click.command()
 @click.argument('nimages', type=int)
 def main(nimages: int):
-    frames = libertem_dectris.FrameIterator()
+    frames = libertem_dectris.FrameIterator(uri="tcp://127.0.0.1:9999")
 
     ec = DEigerClient('localhost', 8910)
 


### PR DESCRIPTION
- Added `libertem_dectris.headers` submodule that exports header classes
- Added constructors for `libertem_dectris.Frame` and `libertem_dectris.FrameStack`
  objects from Python, mostly useful for testing
- Added binding to random port for the simulator
- Properly parametrize with zmq endpoint URI
- Fix many clippy complaints