### PR TITLE
Add decompression into numpy arrays

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
         manylinux: auto
         command: build
         container: ghcr.io/libertem/manylinux2014_x86_64:latest
-        args: --release --sdist -o dist --find-interpreter
+        args: --release --sdist -o target/dist --find-interpreter
     - name: Upload wheels
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: wheels
-        path: dist
+        path: target/dist
 
   windows:
     runs-on: windows-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: recursive
     - uses: messense/maturin-action@v1
       with:
         manylinux: auto

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,7 @@ jobs:
       with:
         manylinux: auto
         command: build
+        container: ghcr.io/libertem/manylinux2014_x86_64:latest
         args: --release --sdist -o dist --find-interpreter
     - name: Upload wheels
       uses: actions/upload-artifact@v2
@@ -25,7 +26,19 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
+    - name: Install LLVM and Clang # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797
+      uses: KyleMayes/install-llvm-action@v1.5.4
+      # if: matrix.config.os == 'windows-latest'
+      with:
+        version: "14.0"
+        cached: ${{ steps.cache-llvm.outputs.cache-hit }}
+        directory: ${{ runner.temp }}/llvm
+    - name: Set LIBCLANG_PATH
+      run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
+      # if: matrix.config.os == 'windows-latest'
     - uses: actions/checkout@v3
+      with:
+        submodules: recursive
     - uses: messense/maturin-action@v1
       with:
         command: build
@@ -38,8 +51,14 @@ jobs:
 
   macos:
     runs-on: macos-latest
+    env:
+      LIBCLANG_PATH: $(brew --prefix llvm@14)/bin/clang
     steps:
+    - name: Set LIBCLANG_PATH
+      run: echo "LIBCLANG_PATH=$(brew --prefix llvm@14)/lib" >> $env:GITHUB_ENV
     - uses: actions/checkout@v3
+      with:
+        submodules: recursive
     - uses: messense/maturin-action@v1
       with:
         command: build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,8 +51,6 @@ jobs:
 
   macos:
     runs-on: macos-latest
-    env:
-      LIBCLANG_PATH: $(brew --prefix llvm@14)/bin/clang
     steps:
     - name: Set LIBCLANG_PATH
       run: echo "LIBCLANG_PATH=$(brew --prefix llvm@14)/lib" >> $env:GITHUB_ENV

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/bitshuffle"]
+	path = vendor/bitshuffle
+	url = git@github.com:kiyo-masui/bitshuffle.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,24 @@
 version = 3
 
 [[package]]
-name = "arc-swap"
-version = "1.5.1"
+name = "ahash"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "atty"
@@ -35,6 +49,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "clap",
+ "env_logger",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,16 +84,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "clap"
-version = "3.2.16"
+name = "clang-sys"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
+checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
 dependencies = [
  "atty",
  "bitflags",
@@ -71,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.15"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
+checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -170,6 +227,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "error-chain"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +261,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hashbrown"
@@ -206,6 +288,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
@@ -230,28 +318,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
-name = "libc"
-version = "0.2.127"
+name = "lazy_static"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "libc"
+version = "0.2.132"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libertem-dectris"
 version = "0.2.1"
 dependencies = [
  "bincode",
+ "bindgen",
+ "cc",
  "clap",
  "crossbeam",
  "crossbeam-channel",
  "log",
  "memmap2",
+ "numpy",
  "pyo3",
- "pyo3-log",
  "serde",
  "serde_json",
  "spin_sleep",
  "uuid",
  "zmq",
+]
+
+[[package]]
+name = "libloading"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+dependencies = [
+ "cfg-if",
+ "winapi",
 ]
 
 [[package]]
@@ -274,10 +386,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "memmap2"
-version = "0.5.6"
+name = "matrixmultiply"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2e4455be2010e8c5e77f0d10234b30f3a636a5305725609b5a71ad00d22577"
+checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
+dependencies = [
+ "rawpointer",
+]
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memmap2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
 dependencies = [
  "libc",
 ]
@@ -303,16 +430,88 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.13.0"
+name = "minimal-lexical"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "numpy"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c4ecda873842a954a8a007d1bfd7c0c6ff88a08ca8b1c4a9a6004efd230287"
+dependencies = [
+ "ahash",
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pyo3",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.2.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "parking_lot"
@@ -336,6 +535,12 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pkg-config"
@@ -384,13 +589,14 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.16.5"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6302e85060011447471887705bb7838f14aba43fcb06957d823739a496b3dc"
+checksum = "68746a80543d80e9676e348d94e50d45cc25f19237dddfa2b61f2f02fc67670e"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
+ "memoffset",
  "parking_lot",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -400,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.16.5"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b65b546c35d8a3b1b2f0ddbac7c6a569d759f357f2b9df884f5d6b719152c8"
+checksum = "0a35ea0dde58f923bcd30f0f9a64e79033cd51e176c32bd50efccbbe7f289b25"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -410,30 +616,19 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.16.5"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c275a07127c1aca33031a563e384ffdd485aee34ef131116fcd58e3430d1742b"
+checksum = "79d0d60ae1b65b927c019352e16b94ff27cedee79916f017215dab3afe2a5cb3"
 dependencies = [
  "libc",
  "pyo3-build-config",
 ]
 
 [[package]]
-name = "pyo3-log"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84f1cb4bfeb767e1913b5e79fb86c1db083404296a650a7689a96371f7d30ea"
-dependencies = [
- "arc-swap",
- "log",
- "pyo3",
-]
-
-[[package]]
 name = "pyo3-macros"
-version = "0.16.5"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284fc4485bfbcc9850a6d661d627783f18d19c2ab55880b021671c4ba83e90f7"
+checksum = "9161973e2e1c245ddae80fe1a140df45197adf45da68a88832b6094acccf5343"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -443,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.16.5"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bda0f58f73f5c5429693c96ed57f7abdb38fdfc28ae06da4101a257adb7faf"
+checksum = "fedb3744eda135dbb40587ddf3e49b36b71903bad5b391c19b4862928c3cf424"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -492,6 +687,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +700,29 @@ checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "ryu"
@@ -514,18 +738,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -534,14 +758,20 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa",
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "smallvec"
@@ -636,6 +866,17 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "which"
+version = "4.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libertem-dectris"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ crossbeam = "0.8.2"
 crossbeam-channel = "0.5.6"
 log = "0.4.17"
 memmap2 = "0.5.6"
-pyo3 = { version = "0.16.5", features = ["extension-module", "abi3-py37"] }
-pyo3-log = "0.6.0"
+numpy = "0.17.0"
+pyo3 = { version = "0.17", features = ["extension-module", "abi3-py37"] }
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
 spin_sleep = "1.1.1"
@@ -32,3 +32,7 @@ zmq = { version = "0.9.2", features = ["vendored"] }
 
 [profile.release]
 debug = true
+
+[build-dependencies]
+bindgen = "0.60.1"
+cc = "1.0.73"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libertem-dectris"
 authors = ["Alexander Clausen <a.clausen@fz-juelich.de>"]
 license = "MIT"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 readme = "README.md"
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,62 @@
+extern crate bindgen;
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    // Tell cargo to look for shared libraries in the specified directory
+    //println!("cargo:rustc-link-search=/path/to/lib");
+
+    // Tell cargo to tell rustc to link the system bzip2
+    // shared library.
+    //println!("cargo:rustc-link-lib=bz2");
+
+    // Tell cargo to invalidate the built crate whenever the wrapper changes
+    println!("cargo:rerun-if-changed=vendor/wrapper.h");
+
+    cc::Build::new()
+        .include("vendor/bitshuffle/lz4")
+        .include("vendor/bitshuffle")
+        .file("vendor/bitshuffle/src/bitshuffle.c")
+        .file("vendor/bitshuffle/src/bitshuffle_core.c")
+        .file("vendor/bitshuffle/src/iochain.c")
+        .file("vendor/bitshuffle/lz4/lz4.c")
+        // FIXME: extract from bitshuffle setup.py directly?
+        .define("BSHUF_VERSION_MAJOR", "0")
+        .define("BSHUF_VERSION_MINOR", "4")
+        .define("BSHUF_VERSION_POINT", "2")
+        // compiler flags stolen from setup.py:
+        .flag_if_supported("-O3")
+        .flag_if_supported("-ffast-math")
+        .flag_if_supported("-std=c99")
+        .flag_if_supported("-fno-strict-aliasing")
+        .flag_if_supported("-fPIC")
+        .flag_if_supported("/Ox")
+        .flag_if_supported("/fp:fast")
+        .compile("bitshuffle");
+
+    // The bindgen::Builder is the main entry point
+    // to bindgen, and lets you build up options for
+    // the resulting bindings.
+    let bindings = bindgen::Builder::default()
+        // The input header we would like to generate
+        // bindings for.
+        .header("vendor/wrapper.h")
+        // Tell cargo to invalidate the built crate whenever any of the
+        // included header files changed.
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .clang_arg("-Ivendor/bitshuffle/src/")
+        .allowlist_function("bshuf_compress_lz4")
+        .allowlist_function("bshuf_decompress_lz4")
+        .allowlist_function("bshuf_compress_lz4_bound")
+        // Finish the builder and generate the bindings.
+        .generate()
+        // Unwrap the Result and panic on failure.
+        .expect("Unable to generate bindings");
+
+    // Write the bindings to the $OUT_DIR/bindings.rs file.
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/build.rs
+++ b/build.rs
@@ -36,16 +36,12 @@ fn main() {
          .flag_if_supported("/fp:fast")
          .flag_if_supported("-w");
 
-    if let Ok(extra_include_path) = env::var("BINDGEN_C_INCLUDE_PATH") {
-        build.include(extra_include_path);
-    }
-
     build.compile("bitshuffle");
 
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
     // the resulting bindings.
-    let bindings = bindgen::Builder::default()
+    let mut bindings_builder = bindgen::Builder::default()
         // The input header we would like to generate
         // bindings for.
         .header("vendor/wrapper.h")
@@ -55,7 +51,14 @@ fn main() {
         .clang_arg("-Ivendor/bitshuffle/src/")
         .allowlist_function("bshuf_compress_lz4")
         .allowlist_function("bshuf_decompress_lz4")
-        .allowlist_function("bshuf_compress_lz4_bound")
+        .allowlist_function("bshuf_compress_lz4_bound");
+
+    if let Ok(extra_include_path) = env::var("BINDGEN_C_INCLUDE_PATH") {
+        let arg = format!("-I{extra_include_path}");
+        bindings_builder = bindings_builder.clang_arg(arg);
+    }
+
+    let bindings = bindings_builder
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.

--- a/build.rs
+++ b/build.rs
@@ -16,25 +16,26 @@ fn main() {
 
     let mut build = cc::Build::new();
 
-    build.include("vendor/bitshuffle/lz4")
-         .include("vendor/bitshuffle")
-         .file("vendor/bitshuffle/src/bitshuffle.c")
-         .file("vendor/bitshuffle/src/bitshuffle_core.c")
-         .file("vendor/bitshuffle/src/iochain.c")
-         .file("vendor/bitshuffle/lz4/lz4.c")
-         // FIXME: extract from bitshuffle setup.py directly?
-         .define("BSHUF_VERSION_MAJOR", "0")
-         .define("BSHUF_VERSION_MINOR", "4")
-         .define("BSHUF_VERSION_POINT", "2")
-         // compiler flags stolen from setup.py:
-         .flag_if_supported("-O3")
-         .flag_if_supported("-ffast-math")
-         .flag_if_supported("-std=c99")
-         .flag_if_supported("-fno-strict-aliasing")
-         .flag_if_supported("-fPIC")
-         .flag_if_supported("/Ox")
-         .flag_if_supported("/fp:fast")
-         .flag_if_supported("-w");
+    build
+        .include("vendor/bitshuffle/lz4")
+        .include("vendor/bitshuffle")
+        .file("vendor/bitshuffle/src/bitshuffle.c")
+        .file("vendor/bitshuffle/src/bitshuffle_core.c")
+        .file("vendor/bitshuffle/src/iochain.c")
+        .file("vendor/bitshuffle/lz4/lz4.c")
+        // FIXME: extract from bitshuffle setup.py directly?
+        .define("BSHUF_VERSION_MAJOR", "0")
+        .define("BSHUF_VERSION_MINOR", "4")
+        .define("BSHUF_VERSION_POINT", "2")
+        // compiler flags stolen from setup.py:
+        .flag_if_supported("-O3")
+        .flag_if_supported("-ffast-math")
+        .flag_if_supported("-std=c99")
+        .flag_if_supported("-fno-strict-aliasing")
+        .flag_if_supported("-fPIC")
+        .flag_if_supported("/Ox")
+        .flag_if_supported("/fp:fast")
+        .flag_if_supported("-w");
 
     build.compile("bitshuffle");
 

--- a/build.rs
+++ b/build.rs
@@ -14,26 +14,33 @@ fn main() {
     // Tell cargo to invalidate the built crate whenever the wrapper changes
     println!("cargo:rerun-if-changed=vendor/wrapper.h");
 
-    cc::Build::new()
-        .include("vendor/bitshuffle/lz4")
-        .include("vendor/bitshuffle")
-        .file("vendor/bitshuffle/src/bitshuffle.c")
-        .file("vendor/bitshuffle/src/bitshuffle_core.c")
-        .file("vendor/bitshuffle/src/iochain.c")
-        .file("vendor/bitshuffle/lz4/lz4.c")
-        // FIXME: extract from bitshuffle setup.py directly?
-        .define("BSHUF_VERSION_MAJOR", "0")
-        .define("BSHUF_VERSION_MINOR", "4")
-        .define("BSHUF_VERSION_POINT", "2")
-        // compiler flags stolen from setup.py:
-        .flag_if_supported("-O3")
-        .flag_if_supported("-ffast-math")
-        .flag_if_supported("-std=c99")
-        .flag_if_supported("-fno-strict-aliasing")
-        .flag_if_supported("-fPIC")
-        .flag_if_supported("/Ox")
-        .flag_if_supported("/fp:fast")
-        .compile("bitshuffle");
+    let mut build = cc::Build::new();
+
+    build.include("vendor/bitshuffle/lz4")
+         .include("vendor/bitshuffle")
+         .file("vendor/bitshuffle/src/bitshuffle.c")
+         .file("vendor/bitshuffle/src/bitshuffle_core.c")
+         .file("vendor/bitshuffle/src/iochain.c")
+         .file("vendor/bitshuffle/lz4/lz4.c")
+         // FIXME: extract from bitshuffle setup.py directly?
+         .define("BSHUF_VERSION_MAJOR", "0")
+         .define("BSHUF_VERSION_MINOR", "4")
+         .define("BSHUF_VERSION_POINT", "2")
+         // compiler flags stolen from setup.py:
+         .flag_if_supported("-O3")
+         .flag_if_supported("-ffast-math")
+         .flag_if_supported("-std=c99")
+         .flag_if_supported("-fno-strict-aliasing")
+         .flag_if_supported("-fPIC")
+         .flag_if_supported("/Ox")
+         .flag_if_supported("/fp:fast")
+         .flag_if_supported("-w");
+
+    if let Ok(extra_include_path) = env::var("BINDGEN_C_INCLUDE_PATH") {
+        build.include(extra_include_path);
+    }
+
+    build.compile("bitshuffle");
 
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,5 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
+[project.urls]
+repository = "https://github.com/LiberTEM/LiberTEM-dectris-rs/"

--- a/src/bs.rs
+++ b/src/bs.rs
@@ -1,0 +1,238 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+mod bs_bindings {
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum BitshuffleError {
+    AllocationError = -1,
+    MissingSSE = -11,
+    MissingAVX = -12,
+    InputSizeMult8 = -80,
+    BlockSizeMult8 = -81,
+    DecompressionError = -91,
+    SizeMismatch,
+    InternalError,
+    Other,
+}
+
+impl From<i64> for BitshuffleError {
+    fn from(code: i64) -> Self {
+        match code {
+            -1 => Self::AllocationError,
+            -11 => Self::MissingSSE,
+            -12 => Self::MissingAVX,
+            -80 => Self::InputSizeMult8,
+            -81 => Self::BlockSizeMult8,
+            -91 => Self::DecompressionError,
+            _code => Self::InternalError,
+        }
+    }
+}
+
+pub fn compress_lz4_bound<T>(size_in_elems: u64, block_size: Option<u64>) -> u64 {
+    let block_size = block_size.unwrap_or(0);
+    let elem_size = u64::try_from(std::mem::size_of::<T>()).unwrap();
+    unsafe { bs_bindings::bshuf_compress_lz4_bound(size_in_elems, elem_size, block_size) }
+}
+
+pub fn compress_lz4<T>(in_: &[T], block_size: Option<u64>) -> Result<Vec<u8>, BitshuffleError> {
+    let block_size = block_size.unwrap_or(0);
+    let c_in = in_.as_ptr().cast();
+    let elem_size = u64::try_from(std::mem::size_of::<T>()).unwrap();
+    let size_in_elems = u64::try_from(in_.len()).unwrap();
+
+    let max_out_size_bytes =
+        unsafe { bs_bindings::bshuf_compress_lz4_bound(size_in_elems, elem_size, block_size) };
+    let mut out: Vec<u8> = Vec::with_capacity(usize::try_from(max_out_size_bytes).unwrap());
+    let bytes_used = unsafe {
+        let c_out = out.as_mut_ptr().cast();
+        bs_bindings::bshuf_compress_lz4(c_in, c_out, size_in_elems, elem_size, block_size)
+    };
+    if bytes_used < 0 {
+        return Err(bytes_used.into());
+    }
+    // safety:
+    // 1) count is less than or equal to capacity (should be given by construction, ...):
+    assert!(usize::try_from(bytes_used).unwrap() <= out.capacity());
+    // 2) bshuf_compress_lz4 promises that is has written `count` bytes in `out`
+    unsafe { out.set_len(bytes_used as usize) }
+    Ok(out)
+}
+
+pub fn decompress_lz4<T>(
+    in_: &[u8],
+    out_size: usize, // number of elements
+    block_size: Option<u64>,
+) -> Result<Vec<T>, BitshuffleError> {
+    let block_size = block_size.unwrap_or(0);
+    let mut out: Vec<T> = Vec::with_capacity(out_size);
+    let out_ptr: *mut T = out.as_mut_ptr();
+    decompress_lz4_into(in_, out_ptr, out_size, Some(block_size))?;
+    unsafe { out.set_len(out_size) };
+    Ok(out)
+}
+
+pub fn decompress_lz4_into<T>(
+    in_: &[u8],
+    out: *mut T,
+    out_size: usize, // number of elements
+    block_size: Option<u64>,
+) -> Result<(), BitshuffleError> {
+    let block_size = block_size.unwrap_or(0);
+    let in_ptr = in_.as_ptr().cast();
+    let elem_size = std::mem::size_of::<T>();
+
+    unsafe {
+        let out_ptr = out.cast();
+        let count = bs_bindings::bshuf_decompress_lz4(
+            in_ptr,
+            out_ptr,
+            u64::try_from(out_size).unwrap(),
+            u64::try_from(elem_size).unwrap(),
+            block_size,
+        );
+        if count < 0 {
+            let in_len = in_.len();
+            return Err(count.into());
+        }
+        if count != i64::try_from(in_.len()).unwrap() {
+            return Err(BitshuffleError::SizeMismatch);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_bitshuffle_lz4_u8() {
+        let input = "this is some data".as_bytes();
+        eprintln!("{input:?}");
+
+        let compressed = compress_lz4(input, None).unwrap();
+        eprintln!("{compressed:?}");
+
+        let decompressed: Vec<u8> = decompress_lz4(&compressed, input.len(), None).unwrap();
+        eprintln!("{decompressed:?}");
+
+        assert_eq!(input, decompressed);
+    }
+
+    #[test]
+    fn roundtrip_bitshuffle_lz4_i32() {
+        let input: Vec<i32> = vec![16, 43242, 12, -32123, 975, -78, 2, 0];
+        eprintln!("{input:?}");
+
+        let compressed = compress_lz4(&input, None).unwrap();
+        eprintln!("{compressed:?}");
+
+        let decompressed: Vec<i32> = decompress_lz4(&compressed, input.len(), None).unwrap();
+        eprintln!("{decompressed:?}");
+
+        assert_eq!(input, decompressed);
+    }
+
+    #[test]
+    fn roundtrip_bitshuffle_decompress_too_short() {
+        let input: Vec<i32> = vec![16, 43242, 12, -32123, 975, -78, 2, 0];
+        eprintln!("{input:?}");
+
+        let compressed = compress_lz4(&input, None).unwrap();
+        eprintln!("{compressed:?}");
+
+        let err: Result<_, _> = decompress_lz4::<Vec<i32>>(&compressed, input.len() - 1, None);
+        assert_eq!(err, Err(BitshuffleError::SizeMismatch));
+
+        let err: Result<_, _> = decompress_lz4::<Vec<i32>>(&compressed, 0, None);
+        assert_eq!(err, Err(BitshuffleError::SizeMismatch));
+
+        let err: Result<_, _> = decompress_lz4::<Vec<i32>>(&compressed, input.len() + 1, None);
+        assert_eq!(err, Err(BitshuffleError::SizeMismatch));
+
+        let err: Result<_, _> = decompress_lz4::<Vec<i32>>(&compressed, input.len() + 1000, None);
+        assert_eq!(err, Err(BitshuffleError::SizeMismatch));
+    }
+
+    #[test]
+    fn roundtrip_bitshuffle_lz4_u64() {
+        let input: Vec<u64> = vec![
+            6605535394741060369,
+            1943729968968667107,
+            4434805337173085311,
+            3857399390108534620,
+            42,
+            1399976486432680367,
+            0,
+        ];
+
+        let compressed = compress_lz4(&input, None).unwrap();
+        let decompressed: Vec<u64> = decompress_lz4(&compressed, input.len(), None).unwrap();
+        assert_eq!(input, decompressed);
+    }
+
+    #[test]
+    fn roundtrip_bitshuffle_lz4_i64() {
+        let input: Vec<i64> = vec![
+            6605535394741060369,
+            1943729968968667107,
+            -4434805337173085311,
+            3857399390108534620,
+            42,
+            -1399976486432680367,
+            0,
+        ];
+        eprintln!("{input:?}");
+
+        let compressed = compress_lz4(&input, None).unwrap();
+        eprintln!("{compressed:?}");
+
+        let decompressed: Vec<i64> = decompress_lz4(&compressed, input.len(), None).unwrap();
+        eprintln!("{decompressed:?}");
+
+        assert_eq!(input, decompressed);
+    }
+
+    #[test]
+    fn roundtrip_bitshuffle_lz4_f64() {
+        let input: Vec<f64> = vec![
+            6605535394741060369.0,
+            1943729968968667107.0,
+            -4434805337173085311.0,
+            3857399390108534620.0,
+            42.0,
+            -1399976486432680367.0,
+            -1.8645594,
+            0.63130624,
+            -0.74550843,
+            -0.25914887,
+            -0.43326423,
+            -0.311869,
+            -0.25334516,
+            -0.31615132,
+            -1.84247401,
+            -0.55763137,
+            0.74976962,
+            0.17890207,
+            0.48589075,
+            0.11130236,
+            0.47587833,
+            0.0,
+            -0.0,
+        ];
+        eprintln!("{input:?}");
+
+        let compressed = compress_lz4(&input, None).unwrap();
+        eprintln!("{compressed:?}");
+
+        let decompressed: Vec<f64> = decompress_lz4(&compressed, input.len(), None).unwrap();
+        eprintln!("{decompressed:?}");
+
+        assert_eq!(input, decompressed);
+    }
+}

--- a/src/bs.rs
+++ b/src/bs.rs
@@ -203,10 +203,10 @@ mod tests {
         assert_eq!(err, Err(BitshuffleError::SizeMismatch));
 
         let err: Result<_, _> = decompress_lz4::<Vec<i32>>(&compressed, input.len() + 1, None);
-        assert_eq!(err, Err(BitshuffleError::SizeMismatch));
+        assert_eq!(err, Err(BitshuffleError::DecompressionError));
 
         let err: Result<_, _> = decompress_lz4::<Vec<i32>>(&compressed, input.len() + 1000, None);
-        assert_eq!(err, Err(BitshuffleError::SizeMismatch));
+        assert_eq!(err, Err(BitshuffleError::InternalError));
     }
 
     #[test]

--- a/src/bs.rs
+++ b/src/bs.rs
@@ -96,7 +96,6 @@ pub fn decompress_lz4_into<T>(
             block_size,
         );
         if count < 0 {
-            let in_len = in_.len();
             return Err(count.into());
         }
         if count != i64::try_from(in_.len()).unwrap() {

--- a/src/common.rs
+++ b/src/common.rs
@@ -30,6 +30,7 @@ impl DHeader {
     }
 }
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[pyclass]
 pub enum TriggerMode {

--- a/src/dectris_py.rs
+++ b/src/dectris_py.rs
@@ -119,8 +119,8 @@ impl Frame {
 
     fn decompress_into(slf: PyRef<Self>, out: &PyAny) -> PyResult<()> {
         let arr_u8: Result<&PyArray2<u8>, _> = out.downcast();
-        let arr_u16: Result<&PyArray2<u8>, _> = out.downcast();
-        let arr_u32: Result<&PyArray2<u8>, _> = out.downcast();
+        let arr_u16: Result<&PyArray2<u16>, _> = out.downcast();
+        let arr_u32: Result<&PyArray2<u32>, _> = out.downcast();
 
         match slf.frame.dimaged.encoding.as_str() {
             "bs32-lz4<" => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod bs;
 pub mod common;
 pub mod dectris_py;

--- a/vendor/wrapper.h
+++ b/vendor/wrapper.h
@@ -1,0 +1,1 @@
+#include <bitshuffle.h>


### PR DESCRIPTION
Vendor the `bitshuffle` code and generate a rust+Python binding. This means we don't need to separately install the `bitshuffle` Python package anymore.