### PR TITLE
Improved error handling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/bitshuffle"]
 	path = vendor/bitshuffle
-	url = git@github.com:kiyo-masui/bitshuffle.git
+	url = https://github.com:kiyo-masui/bitshuffle.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/bitshuffle"]
 	path = vendor/bitshuffle
-	url = https://github.com:kiyo-masui/bitshuffle.git
+	url = https://github.com/kiyo-masui/bitshuffle.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,9 +234,9 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
@@ -345,6 +345,7 @@ dependencies = [
  "clap",
  "crossbeam",
  "crossbeam-channel",
+ "env_logger",
  "log",
  "memmap2",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ bincode = "1.3.3"
 clap = { version = "3.2.16", features = ["derive"] }
 crossbeam = "0.8.2"
 crossbeam-channel = "0.5.6"
+env_logger = "0.9.3"
 log = "0.4.17"
 memmap2 = "0.5.6"
 numpy = "0.17.0"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ finally:
 
 ## Changelog
 
+### v0.2.3 (unreleased)
+
+- Add `env_logger`: set environment variable `LIBERTEM_DECTRIS_LOG_LEVEL` to e.g. `'INFO'` to enable logging
+- Improved error handling: raise an exception instead of panicing on serialization errors
+- Ignore messages with mismatching series ID
+
 ### v0.2.2
 
 - Vendor `bitshuffle` and add `Frame.decompress_into` method, PR [#10](https://github.com/LiberTEM/LiberTEM-dectris-rs/pull/10)

--- a/src/common.rs
+++ b/src/common.rs
@@ -12,6 +12,12 @@ use zmq::{Context, Message, Socket, SocketEvent, SocketType::PUSH};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[pyclass]
+pub struct DSeriesOnly {
+    pub series: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[pyclass]
 pub struct DHeader {
     pub htype: String,
     pub header_detail: String,

--- a/src/common.rs
+++ b/src/common.rs
@@ -241,19 +241,16 @@ impl DumpRecordFile {
         while current_offset < self.mmap.len() {
             let (value, size) = self.read_json(current_offset);
 
-            match value {
-                Some(val) => {
-                    let htype = val
-                        .as_object()
-                        .expect("all json messages should be objects")
-                        .get("htype");
-                    if let Some(htype_str) = htype {
-                        if htype_str == expected_htype {
-                            return Some(current_offset);
-                        }
+            if let Some(val) = value {
+                let htype = val
+                    .as_object()
+                    .expect("all json messages should be objects")
+                    .get("htype");
+                if let Some(htype_str) = htype {
+                    if htype_str == expected_htype {
+                        return Some(current_offset);
                     }
                 }
-                None => {}
             }
 
             current_offset += size + 8;

--- a/src/dectris_py.rs
+++ b/src/dectris_py.rs
@@ -416,7 +416,6 @@ fn drain_if_mismatch(
 ) -> Result<(), AcquisitionError> {
     loop {
         let series_res: Result<DSeriesOnly, _> = serde_json::from_str(msg.as_str().unwrap());
-        debug!("drained message header: {}", msg.as_str().unwrap());
 
         if let Ok(recvd_series) = series_res {
             // everything is ok, we can go ahead:
@@ -424,6 +423,8 @@ fn drain_if_mismatch(
                 return Ok(());
             }
         }
+
+        debug!("drained message header: {} expected series {}", msg.as_str().unwrap(), series);
 
         // throw away message parts that are part of the mismatched message:
         while msg.get_more() {

--- a/src/dectris_py.rs
+++ b/src/dectris_py.rs
@@ -44,6 +44,12 @@ fn libertem_dectris(py: Python, m: &PyModule) -> PyResult<()> {
     m.add("DecompressError", py.get_type::<DecompressError>())?;
 
     register_header_module(py, m)?;
+
+    let env = env_logger::Env::default()
+        .filter_or("LIBERTEM_DECTRIS_LOG_LEVEL", "error")
+        .write_style_or("LIBERTEM_DECTRIS_LOG_STYLE", "always");
+    env_logger::init_from_env(env);
+
     Ok(())
 }
 
@@ -421,6 +427,7 @@ fn background_thread(
         match control {
             Ok(ControlMsg::StartAcquisition { series }) => {
                 let mut msg: Message = Message::new();
+                // FIXME: throw away any messages that don't match our current series
                 recv_part(&mut msg, &socket, to_thread_r)?;
                 let dheader_res: Result<DHeader, _> = serde_json::from_str(msg.as_str().unwrap());
                 let dheader: DHeader = match dheader_res {


### PR DESCRIPTION
- Add `env_logger`: set environment variable `LIBERTEM_DECTRIS_LOG_LEVEL` to e.g. `'INFO'` to enable logging
- Improved error handling: raise an exception instead of panicing on serialization errors
- Ignore messages with mismatching series ID
